### PR TITLE
Ensure that prefixes are remove if they exist

### DIFF
--- a/src/AttributeOptionMapper.php
+++ b/src/AttributeOptionMapper.php
@@ -45,6 +45,15 @@ class AttributeOptionMapper
         return $result;
     }
 
+    private static function getDefaultValueIdMapper(): callable
+    {
+        return function (string $value) {
+            $values = explode('-', $value);
+            $value = count($values) >= 2 ? implode('-', array_slice($values, 1)) : $value;
+            return FredhopperAttributeOption::sanitizeValueId($value);
+        };
+    }
+
     private $attributeIdMapper;
     private $valueIdMapper;
     private $displayValueMapper;
@@ -52,7 +61,7 @@ class AttributeOptionMapper
     private function __construct()
     {
         $this->attributeIdMapper = [AttributeData::class, 'sanitizeId'];
-        $this->valueIdMapper = [FredhopperAttributeOption::class, 'sanitizeValueId'];
+        $this->valueIdMapper = self::getDefaultValueIdMapper();
         $this->displayValueMapper = InternationalizedStringMapper::create();
     }
 }

--- a/test/unit/AttributeOptionMapperTest.php
+++ b/test/unit/AttributeOptionMapperTest.php
@@ -36,6 +36,15 @@ class AttributeOptionMapperTest extends TestCase
         self::assertTrue($expected->equals($actual));
     }
 
+    public function testMapWithNoLabelsAndSuffixedAttributeCode()
+    {
+        $mapper = AttributeOptionMapper::create();
+        $attributeOption = AkeneoAttributeOption::of(AttributeOptionIdentifier::of('size', 'size-large'));
+        $expected = AttributeOptionSet::of([FredhopperAttributeOption::of('size', 'large')]);
+        $actual = $mapper($attributeOption);
+        self::assertTrue($expected->equals($actual));
+    }
+
     public function testMapWithLabels()
     {
 


### PR DESCRIPTION
# Overview

The attribute id is suffixed to the attribute option code

### This PR will check the attribute option code and if it suffixed
- It will use the attribute option code without the suffix
else:
- It will use the attribute as is.